### PR TITLE
Updated README.md to account for ggplot2 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ ggthemr_reset()
 Known issues
 -------------------------
 
-Due to a bug in ggplot2 some `geom`s may return errors such as `Error: Unknown colour name: a`. See [here](https://github.com/tidyverse/ggplot2/issues/4149)
+Due to a bug in ggplot2 some `geom`s may return errors such as `Error: Unknown colour name: a`. See [here](https://github.com/tidyverse/ggplot2/issues/4149).
+
+In more recent versions of ggplot2 the error no longer occurs but in some instances the default ggplot colours will be used instead of the set theme.
 
 To avoid this and keep using ggthemr colours in these instances, please add a `scale_colour_ggthemr_d()` layer to your ggplot call.
 
@@ -65,6 +67,8 @@ ggplot(mtcars, aes(mpg, disp, colour = factor(am))) +
     geom_point() +
     scale_colour_ggthemr_d()
 ```
+
+This is the same as adding `scale_colour_manual(fill = some_colours)` but will always use the theme colours in your set theme.
 
 Palettes
 --------

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 -   [ggthemr](#ggthemr)
     -   [Installation](#installation)
     -   [Usage](#usage)
+    -   [Known Issues](#known-issues)
     -   [Palettes](#palettes)
     -   [Custom Palettes](#custom-palettes)
     -   [Layouts](#layouts)
@@ -51,7 +52,7 @@ That's it. Any ggplot you create from then on will have the theme applied. You c
 ggthemr_reset()
 ```
 
-Known issues
+Known Issues
 -------------------------
 
 Due to a bug in ggplot2 some `geom`s may return errors such as `Error: Unknown colour name: a`. See [here](https://github.com/tidyverse/ggplot2/issues/4149).


### PR DESCRIPTION
ggplot fixed their upstream issue (see tidyverse/ggplot2#4149) but instead of throwing an error there are still some
cases where it uses the default colours as opposed to the set themes ones. So this is just to update the readme to make
this clear.

Until we find what is causing the colour to use defaults I suppose #44 should remain open.