### PR TITLE
Default colour scales fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# ggthemr (development version) - 2021-12-11
+
+* Fixed default colour scales when specifying `colour=` in `aes()`
+
 # ggthemr (development version) - 2020-11-15
 
 * Use `options()` for scale functions (ggplot2 >= 3.3.2, specifically after this [PR](https://github.com/tidyverse/ggplot2/issues/3827))

--- a/R/ggthemr.R
+++ b/R/ggthemr.R
@@ -52,11 +52,11 @@ ggthemr <- function(palette     = 'dust',
   # setting the scales
   colours <- palette$swatch[-1]
   options('ggplot2.discrete.fill' = function(...) discrete_scale('fill', 'ggthemr', discrete_colours(colours), ...))
-  options('ggplot2.discrete.color' = function(...) discrete_scale('colour', 'ggthemr', discrete_colours(colours), ...))
+  options('ggplot2.discrete.colour' = function(...) discrete_scale('colour', 'ggthemr', discrete_colours(colours), ...))
   options('ggplot2.continuous.fill' = function(...) continuous_scale('fill', 'ggthemr',
                                                                      seq_gradient_pal(palette$gradient[['low']], palette$gradient[['high']], 'Lab'),
                                                                      guide = 'colourbar', ...))
-  options('ggplot2.continuous.color' = function(...) continuous_scale('colour', 'ggthemr',
+  options('ggplot2.continuous.colour' = function(...) continuous_scale('colour', 'ggthemr',
                                                                       seq_gradient_pal(palette$gradient[['low']], palette$gradient[['high']], 'Lab'),
                                                                       guide = 'colourbar', ...))
 

--- a/README.md
+++ b/README.md
@@ -54,18 +54,6 @@ ggthemr_reset()
 Known issues
 -------------------------
 
-Due to a bug in ggplot2 some `geom`s may return errors such as `Error: Unknown colour name: a`. See [here](https://github.com/tidyverse/ggplot2/issues/4149)
-
-To avoid this and keep using ggthemr colours in these instances, please add a `scale_colour_ggthemr_d()` layer to your ggplot call.
-
-For example:
-
-```r
-ggplot(mtcars, aes(mpg, disp, colour = factor(am))) +
-    geom_point() +
-    scale_colour_ggthemr_d()
-```
-
 Palettes
 --------
 


### PR DESCRIPTION
I've finally had a chance to look at this issue in more depth, and tracked down the root of the issue: ggplot2 options **only** seem to use the *British spelling* when using the colour options. Thanks to @lotard with their tidyverse/ggplot2#4626 issue which pointed me in the right direction.

This fixes #44. And as such should hopefully open this up to a CRAN release at some point. 